### PR TITLE
feat: improve wizard UI

### DIFF
--- a/src/app/simulation/etapes/ButtonsFunnel.tsx
+++ b/src/app/simulation/etapes/ButtonsFunnel.tsx
@@ -20,6 +20,7 @@ export const ButtonsFunnel = ({ disabled }: Props = { disabled: false }) => {
         <ButtonsWrapper align="center">
           {!isFirstStep && (
             <Button
+              type="button"
               priority="tertiary"
               iconId="fr-icon-arrow-left-line"
               nativeButtonProps={{

--- a/src/app/simulation/etapes/Step4/index.tsx
+++ b/src/app/simulation/etapes/Step4/index.tsx
@@ -13,8 +13,9 @@ import { WizardForm } from "../WizardForm";
 const schema = z.object({
   nbLogements: z.coerce
     .number({
-      invalid_type_error: "Le nombre de logements doit être un nombre",
+      invalid_type_error: "Le nombre de logements doit être un nombre entier",
     })
+    .int()
     .min(1, "Le nombre de logements est obligatoire et supérieur à zéro"),
 });
 
@@ -40,6 +41,10 @@ export const Step4 = () => {
                     placeholder: "Nombre de logements",
                     name: "nbLogements",
                     defaultValue: initialState?.nbLogements,
+                    type: "number",
+                    onBlur: e => {
+                      e.target.value = String(Math.round(Number(e.target.value)));
+                    },
                   }}
                   state={errors?.nbLogements?._errors ? "error" : "default"}
                   stateRelatedMessage={errors?.nbLogements?._errors}

--- a/src/app/simulation/etapes/Step5/index.tsx
+++ b/src/app/simulation/etapes/Step5/index.tsx
@@ -43,7 +43,7 @@ export const Step5 = () => {
 
   useEffect(() => {
     if (sessionStorageOK) {
-      setRadioState(initialState?.possedeEspacesExterieursCommuns as (typeof OuiNonLabels)[number]);
+      setRadioState((initialState?.possedeEspacesExterieursCommuns as (typeof OuiNonLabels)[number]) ?? "Oui");
     }
   }, [sessionStorageOK, initialState]);
 

--- a/src/app/simulation/etapes/Step6/index.tsx
+++ b/src/app/simulation/etapes/Step6/index.tsx
@@ -43,7 +43,7 @@ export const Step6 = () => {
 
   useEffect(() => {
     if (sessionStorageOK) {
-      setRadioState(initialState?.possedeEspacesExterieursPersonnels as (typeof OuiNonLabels)[number]);
+      setRadioState((initialState?.possedeEspacesExterieursCommuns as (typeof OuiNonLabels)[number]) ?? "Oui");
     }
   }, [sessionStorageOK, initialState]);
 

--- a/src/app/simulation/etapes/Step6/index.tsx
+++ b/src/app/simulation/etapes/Step6/index.tsx
@@ -74,14 +74,17 @@ export const Step6 = () => {
                   legend=""
                   name="possedeEspacesExterieursPersonnels"
                   segments={
-                    OuiNonLabels.map(label => ({
-                      label,
-                      nativeInputProps: {
-                        value: label,
-                        checked: radioState === label,
-                        onChange: () => setRadioState(label),
-                      },
-                    })) as unknown as SegmentedControlProps.Segments
+                    OuiNonLabels.map(
+                      label =>
+                        ({
+                          label,
+                          nativeInputProps: {
+                            value: label,
+                            checked: radioState === label,
+                            onChange: () => setRadioState(label),
+                          },
+                        }) satisfies SegmentedControlProps.SegmentWithoutIcon,
+                    ) as unknown as SegmentedControlProps.Segments
                   }
                 />
 

--- a/src/app/simulation/etapes/WizardForm.tsx
+++ b/src/app/simulation/etapes/WizardForm.tsx
@@ -1,6 +1,6 @@
 import { Base64 } from "js-base64";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useWizard } from "react-use-wizard";
 import { z, type ZodFormattedError } from "zod";
 
@@ -77,6 +77,10 @@ export const WizardForm = ({ schema, render }: Props) => {
   const { nextStep, isLastStep } = useWizard();
   const [errors, setErrors] = useState<ZodFormattedError<{ [x: string]: unknown }, string>>();
   const router = useRouter();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const formAction = useCallback(
     (result: HandleFormResult) => {

--- a/src/app/simulation/etapes/WizardForm.tsx
+++ b/src/app/simulation/etapes/WizardForm.tsx
@@ -104,7 +104,7 @@ export const WizardForm = ({ schema, render }: Props) => {
 
   return (
     <>
-      <form onSubmit={handleForm(schema, formAction)}>
+      <form onSubmit={handleForm(schema, formAction)} noValidate>
         {render({ errors })}
 
         <ButtonsFunnel />

--- a/src/app/simulation/resultat/NouvelleSimulation.tsx
+++ b/src/app/simulation/resultat/NouvelleSimulation.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/Button";
+import { store } from "@/lib/client/store";
+
+export const NouvelleSimulation = () => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    store.clear();
+    router.push("/simulation");
+  };
+
+  return (
+    <>
+      <Button priority="tertiary no outline" iconId="ri-arrow-right-line" onClick={() => handleClick()}>
+        Je veux démarrer une nouvelle simulation
+      </Button>
+    </>
+  );
+};

--- a/src/app/simulation/resultat/loading.tsx
+++ b/src/app/simulation/resultat/loading.tsx
@@ -1,3 +1,12 @@
+import { fr } from "@codegouvfr/react-dsfr";
+
+import { Box } from "@/dsfr";
+import { Text } from "@/dsfr/base/typography";
+
 export default function Loading() {
-  return "Chargement...";
+  return (
+    <Box className={fr.cx("fr-mt-8w")}>
+      <Text variant="xl">Chargement...</Text>
+    </Box>
+  );
 }

--- a/src/app/simulation/resultat/page.tsx
+++ b/src/app/simulation/resultat/page.tsx
@@ -22,6 +22,7 @@ import {
 import { JaugeCoutlImage } from "./JaugeCoutlImage";
 import { JaugeDifficulteImage } from "./JaugeDifficulteImage";
 import { JaugeEnvironnementalImage } from "./JaugeEnvironnementalImage";
+import { NouvelleSimulation } from "./NouvelleSimulation";
 
 const ResultatsPage = async ({ searchParams }: { searchParams: { complet: "non" | "oui"; hash: string } }) => {
   if (!searchParams.hash) throw new Error("Le hash est manquant");
@@ -66,7 +67,17 @@ const ResultatsPage = async ({ searchParams }: { searchParams: { complet: "non" 
         </H4>
 
         <Text>
-          Nous avons trouvé <strong>{solutions.data.length} solutions</strong> de chauffage adaptées à votre bâtiment.
+          {solutions.data.length === 0 ? (
+            <>Nous n'avons pas trouvé de solution de chauffage adaptée à votre bâtiment.</>
+          ) : (
+            <>
+              Nous avons trouvé{" "}
+              <strong>
+                {solutions.data.length} solution{solutions.data.length > 1 ? "s" : ""}
+              </strong>{" "}
+              de chauffage adaptées à votre bâtiment.
+            </>
+          )}
         </Text>
 
         <Grid haveGutters>
@@ -164,7 +175,7 @@ const ResultatsPage = async ({ searchParams }: { searchParams: { complet: "non" 
             </GridCol>
           ))}
         </Grid>
-        {!complet && (
+        {!complet && solutions.data.length > 3 && (
           <Box className={cx("flex", fr.cx("fr-mt-4w"))}>
             <Button
               priority="tertiary"
@@ -177,6 +188,12 @@ const ResultatsPage = async ({ searchParams }: { searchParams: { complet: "non" 
             </Button>
           </Box>
         )}
+
+        <Grid>
+          <GridCol className={fr.cx("fr-mt-6w")}>
+            <NouvelleSimulation />
+          </GridCol>
+        </Grid>
       </Container>
     </>
   );


### PR DESCRIPTION
- accessibilité : dans le simulateur, un appui sur Entrée dans un champ fait passer à l'étape suivante 
- pour les étapes 5 et 6 (espaces extérieurs), la case Oui est maintenant précochée pour que l'accessibilité au clavier fonctionne (limite du composant DSFR, cas remonté à l'équipe DSFR)
- quand on passe d'étape en étape, on remonte en haut de la page. Meilleure expérience mobile.
- nouveau bouton en fin de simulation pour pouvoir recommencer une nouvelle simulation de zéro.
- page de chargement
- wording page de résultat. Pas de s quand 1 seule solution. Phrase si pas de résultat, même si ce cas n'est pas censé arriver.
- nombre de logements : champ numérique. Quand on sort du champ, si le nombre est à virgule, on l'arrondit
