### PR TITLE
fix: appel du simu 1 en mode global pour avoir toutes les solutions possibles

### DIFF
--- a/src/app/simulation/resultat/WrapperResultatDetail.tsx
+++ b/src/app/simulation/resultat/WrapperResultatDetail.tsx
@@ -201,12 +201,15 @@ export const WrapperResultatDetail = ({
           <Button
             priority="tertiary no outline"
             className={cx("grow", "md:grow-0", "justify-center")}
-            linkProps={{
-              href: `/simulation/resultat?${createSearchParams<ResultatsPageSearchParamsProps["complet"]>({
-                searchParams,
-                name: "complet",
-                value: "oui",
-              })}`,
+            onClick={() => {
+              router.push(
+                `/simulation/resultat?${createSearchParams<ResultatsPageSearchParamsProps["complet"]>({
+                  searchParams,
+                  name: "complet",
+                  value: "oui",
+                })}`,
+                { scroll: false },
+              );
             }}
           >
             Voir plus de solutions

--- a/src/app/simulation/resultat/helper.tsx
+++ b/src/app/simulation/resultat/helper.tsx
@@ -45,7 +45,11 @@ export const fetchSolutions = async ({
   complet = false,
 }: FetchSolutionsParams): Promise<FetchSolutionsReturnType> => {
   const [baseSolutions, adresses] = await Promise.all([
-    getSolutionsApplicablesMemoized(informationBatiment),
+    getSolutionsApplicablesMemoized(
+      travauxNiveauIsolation === "Global"
+        ? { ...informationBatiment, renovation: ["fenetres", "sol", "toiture", "murs"] }
+        : informationBatiment,
+    ),
     fetchBAN(informationBatiment.adresse),
   ]);
 

--- a/src/components/IsolationSegmentedControl.tsx
+++ b/src/components/IsolationSegmentedControl.tsx
@@ -48,6 +48,7 @@ export const TravauxNiveauIsolationSegmentedControl = ({ travauxNiveauIsolation 
                     name: "travauxNiveauIsolation",
                     value: label,
                   })}`,
+                  { scroll: false },
                 );
               },
             },


### PR DESCRIPTION
## Contexte

Céline est suprise de ne pas voir la solution PAC géothermie avec cette simulation, quand l'onglet est sur Global.

https://pacoupa.ademe.fr/simulation/resultat?hash=eyJhZHJlc3NlIjoiNTAgQXZlbnVlIExlZHJ1LVJvbGxpbiA3NTAxMiBQYXJpcyIsImFubmVlIjoxOTgzLCJyZW5vdmF0aW9uIjpbImZlbmV0cmVzIl0sIm5iTG9nZW1lbnRzIjoyMCwicG9zc2VkZUVzcGFjZXNFeHRlcmlldXJzQ29tbXVucyI6Ik91aSIsImVzcGFjZXNFeHRlcmlldXJzQ29tbXVucyI6WyJqYXJkaW4iLCJwYXJraW5nIGV4dGVyaWV1ciJdLCJwb3NzZWRlRXNwYWNlc0V4dGVyaWV1cnNQZXJzb25uZWxzIjoiTm9uIiwidHlwZUNIIjoiY29sbGVjdGlmIiwiZW5lcmdpZUNIIjoiZ2F6IiwiZW1ldHRldXIiOiJyYWRpYXRldXJzIiwidHlwZUVDUyI6ImNvbGxlY3RpZiIsImVuZXJnaWVFQ1MiOiJnYXoifQ==

Effectivement, le calcul des solutions applicables (simulateur 1) n'était pas conditionné au fait que le calcul est à faire avec tous les gestes d'isolation faits ou non. Dans le simulateur 1, quand la réno est globale ou l'année > 2000, des solutions supplémentaires peuvent apparaître. 

