### PR TITLE
feat: add fcu deep link with prefilled address

### DIFF
--- a/src/app/simulation/etapes/Step1/index.tsx
+++ b/src/app/simulation/etapes/Step1/index.tsx
@@ -22,7 +22,7 @@ export const Step1 = () => {
         render={({ errors, store }) => (
           <>
             <div>
-              <AutocompleteBan defaultValue={store.adresse} errors={errors?.adresse?._errors} />
+              <AutocompleteBan defaultInputValue={store.adresse} errors={errors?.adresse?._errors} />
             </div>
             <div className="mt-8">
               <Callout

--- a/src/app/simulation/resultat/CardRcu.tsx
+++ b/src/app/simulation/resultat/CardRcu.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/Button";
 import { Callout } from "@/components/Callout";
 import { Card } from "@/components/Card";
 import { Text } from "@/dsfr/base/typography";
+import { usePacoupaSessionStorage } from "@/lib/client/usePacoupaSessionStorage";
 import { type Solution } from "@/lib/common/domain/values/Solution";
 import { matomoCategory } from "@/lib/matomo-events";
 
@@ -21,6 +22,8 @@ const rcuSolution = {
 } satisfies Pick<Solution, "type" | "usageCh" | "usageEcs" | "usageFr">;
 
 export const CardRcu = () => {
+  const { store } = usePacoupaSessionStorage();
+
   return (
     <>
       <Card
@@ -78,7 +81,7 @@ export const CardRcu = () => {
             <Button
               priority="tertiary no outline"
               linkProps={{
-                href: `https://france-chaleur-urbaine.beta.gouv.fr/`,
+                href: `https://france-chaleur-urbaine.beta.gouv.fr/?heating=${store.typeCH}&address=${store.adresse}`,
                 onClick: () => {
                   push(["trackEvent", matomoCategory.resultats, "Clic FCU", "Lien FCU"]);
                 },

--- a/src/components/AutocompleteBan.tsx
+++ b/src/components/AutocompleteBan.tsx
@@ -153,7 +153,7 @@ export function AutocompleteBan({ defaultInputValue, errors }: AutocompletBanMui
             type="warning"
             content={
               <Text className="mb-0">
-                Nous manquons de précisions climatiques sur votre zone géographique. Les résultats trouvés seront moins
+                Désolé, nous manquons de données climatiques pour votre ville. Les résultats pourraient être moins
                 précis.
               </Text>
             }

--- a/src/components/AutocompleteBan.tsx
+++ b/src/components/AutocompleteBan.tsx
@@ -8,19 +8,30 @@ import { useEffect, useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
 
 import { Text } from "@/dsfr/base/typography";
+import { isCodePostalSupporte } from "@/lib/server/useCases/getZonesClimatiques";
 import { type FeatureCollection, fetchBAN } from "@/lib/services/ban";
+
+import { Callout } from "./Callout";
 
 const minCharactersBeforeFetching = 10;
 
-type AutocompletBanMuiProps = { defaultValue?: string; errors: string[] | undefined };
+type AutocompletBanMuiProps = { defaultInputValue?: string; errors: string[] | undefined };
 
-export function AutocompleteBan({ defaultValue, errors }: AutocompletBanMuiProps) {
+export function AutocompleteBan({ defaultInputValue, errors }: AutocompletBanMuiProps) {
   const [value, setValue] = useState<FeatureCollection | null>(null);
-  const [inputValue, setInputValue] = useState(defaultValue || "");
+  const [inputValue, setInputValue] = useState(defaultInputValue || "");
   const [options, setOptions] = useState<readonly FeatureCollection[]>([]);
   const [loading, setLoading] = useState(false);
 
   const [debouncedInputValue, setDebouncedInputValue] = useDebounceValue("", 300);
+
+  const isCom = !value
+    ? false //  at start, when no value specified
+    : !value.properties.postcode
+      ? true // some cases when there is no postcode
+      : !isCodePostalSupporte(value.properties.postcode)
+        ? true // postcode not supported, like 97, 98
+        : false; // in metropolitan France
 
   useEffect(() => {
     setDebouncedInputValue(inputValue);
@@ -28,8 +39,8 @@ export function AutocompleteBan({ defaultValue, errors }: AutocompletBanMuiProps
 
   useEffect(() => {
     const fetchInitialData = async () => {
-      if (defaultValue) {
-        const proposals = (await fetchBAN(defaultValue)).features;
+      if (defaultInputValue) {
+        const proposals = (await fetchBAN(defaultInputValue)).features;
 
         setValue(proposals[0]);
         setOptions(proposals);
@@ -37,7 +48,7 @@ export function AutocompleteBan({ defaultValue, errors }: AutocompletBanMuiProps
     };
 
     fetchInitialData().catch(console.error);
-  }, [defaultValue]);
+  }, [defaultInputValue]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -57,83 +68,98 @@ export function AutocompleteBan({ defaultValue, errors }: AutocompletBanMuiProps
   }, [debouncedInputValue]);
 
   return (
-    <Autocomplete
-      id="ban-autocomplete"
-      getOptionLabel={option => (typeof option === "string" ? option : option.properties.label)}
-      filterOptions={x => x}
-      options={options}
-      autoComplete
-      includeInputInList
-      filterSelectedOptions
-      value={value}
-      aria-required="true"
-      noOptionsText="Pas de résultat"
-      isOptionEqualToValue={(option, value) => option.properties.label === value?.properties?.label}
-      onChange={(_event: unknown, newValue: FeatureCollection | null) => {
-        setOptions(newValue ? [newValue, ...options] : options);
-        setValue(newValue);
-      }}
-      onInputChange={(_event, newInputValue) => {
-        setInputValue(newInputValue);
-      }}
-      renderInput={params => (
-        <>
-          <TextField
-            {...params}
-            label="Quelle est votre adresse ?"
-            name="adresse"
-            fullWidth
-            aria-required="true"
-            placeholder="Ex: 8 Boulevard de la Libération, 93200 Saint-Denis"
-            InputProps={{
-              ...params.InputProps,
-              "aria-required": true,
-              "aria-invalid": Boolean(errors && errors.length),
-              "aria-describedby": "adresse-error",
-              endAdornment: (
-                <>
-                  {loading ? <CircularProgress color="inherit" size={20} /> : null}
-                  {params.InputProps.endAdornment}
-                </>
-              ),
-            }}
+    <>
+      <Autocomplete
+        id="ban-autocomplete"
+        getOptionLabel={option => (typeof option === "string" ? option : option.properties.label)}
+        filterOptions={x => x}
+        options={options}
+        autoComplete
+        includeInputInList
+        filterSelectedOptions
+        value={value}
+        aria-required="true"
+        noOptionsText="Pas de résultat"
+        isOptionEqualToValue={(option, value) => option.properties.label === value?.properties?.label}
+        onChange={(_event: unknown, newValue: FeatureCollection | null) => {
+          setOptions(newValue ? [newValue, ...options] : options);
+          setValue(newValue);
+        }}
+        onInputChange={(_event, newInputValue) => {
+          setInputValue(newInputValue);
+        }}
+        renderInput={params => (
+          <>
+            <TextField
+              {...params}
+              label="Quelle est votre adresse ?"
+              name="adresse"
+              fullWidth
+              aria-required="true"
+              placeholder="Ex: 8 Boulevard de la Libération, 93200 Saint-Denis"
+              InputProps={{
+                ...params.InputProps,
+                "aria-required": true,
+                "aria-invalid": Boolean(errors && errors.length),
+                "aria-describedby": "adresse-error",
+                endAdornment: (
+                  <>
+                    {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+            {errors && (
+              <>
+                <div id="adresse-error" className={fr.cx("fr-error-text")} aria-live="polite">
+                  {errors[0]}
+                </div>
+              </>
+            )}
+          </>
+        )}
+        renderOption={(props, option) => {
+          if (!inputValue) return null;
+
+          // Make words matching the input bold.
+          const matches = match(option.properties.label, inputValue);
+          const parts = parse(option.properties.label, matches);
+
+          // @ts-expect-error - `key` is provided by Autocomplete and React doesn't want to pass it with spread props.
+          const { key: _key, ...rest } = props;
+
+          return (
+            <li key={option.properties.label} {...rest}>
+              <Grid container alignItems="center">
+                <Grid item sx={{ display: "flex", width: 44 }}>
+                  <i className={fr.cx("fr-icon-map-pin-2-fill")} />
+                </Grid>
+                <Grid item sx={{ width: "calc(100% - 44px)", wordWrap: "break-word" }}>
+                  {parts.map(({ text, highlight }, index) => (
+                    <Text inline key={index} className={highlight ? "font-bold" : "font-normal"}>
+                      {text}
+                    </Text>
+                  ))}
+                </Grid>
+              </Grid>
+            </li>
+          );
+        }}
+      />
+      {isCom && (
+        <div className="mt-8">
+          <Callout
+            type="warning"
+            content={
+              <Text className="mb-0">
+                Nous manquons de précisions climatiques sur votre zone géographique. Les résultats trouvés seront moins
+                précis.
+              </Text>
+            }
           />
-          {errors && (
-            <>
-              <div id="adresse-error" className={fr.cx("fr-error-text")} aria-live="polite">
-                {errors[0]}
-              </div>
-            </>
-          )}
-        </>
+        </div>
       )}
-      renderOption={(props, option) => {
-        if (!inputValue) return null;
-
-        // Make words matching the input bold.
-        const matches = match(option.properties.label, inputValue);
-        const parts = parse(option.properties.label, matches);
-
-        // @ts-expect-error - `key` is provided by Autocomplete and React doesn't want to pass it with spread props.
-        const { key: _key, ...rest } = props;
-
-        return (
-          <li key={option.properties.label} {...rest}>
-            <Grid container alignItems="center">
-              <Grid item sx={{ display: "flex", width: 44 }}>
-                <i className={fr.cx("fr-icon-map-pin-2-fill")} />
-              </Grid>
-              <Grid item sx={{ width: "calc(100% - 44px)", wordWrap: "break-word" }}>
-                {parts.map(({ text, highlight }, index) => (
-                  <Text inline key={index} className={highlight ? "font-bold" : "font-normal"}>
-                    {text}
-                  </Text>
-                ))}
-              </Grid>
-            </Grid>
-          </li>
-        );
-      }}
-    />
+    </>
   );
 }

--- a/src/lib/server/useCases/getZonesClimatiques/useCase.ts
+++ b/src/lib/server/useCases/getZonesClimatiques/useCase.ts
@@ -96,6 +96,9 @@ export const zonesClimatiques = {
   "94 - Val-de-Marne": "75 - Paris",
 } as const;
 
+export const isCodePostalSupporte = (codePostal: string) =>
+  Object.keys(zonesClimatiques).some(zone => zone.startsWith(codePostal.substring(0, 2)));
+
 export const getZoneClimatiqueAssociee = (zoneClimatique: string) => {
   const key = Object.keys(zonesClimatiques).find(key =>
     key.startsWith(zoneClimatique),

--- a/src/lib/services/fcu.ts
+++ b/src/lib/services/fcu.ts
@@ -10,7 +10,7 @@ export type FcuEligibility = {
   rateENRR: number;
 };
 
-const FCU_URL = "https://france-chaleur-urbaine-dev.osc-fr1.scalingo.io/api/v1/eligibility";
+const FCU_URL = "https://france-chaleur-urbaine.beta.gouv.fr/api/v1/eligibility";
 
 const ERREUR_RESEAU = "Erreur réseau lors de l'appel à FCU";
 


### PR DESCRIPTION
Dans Pacoupa, avec une adresse éligible au RCU
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/a86728d9-654e-4706-9fdb-2483d4e56c6c">

Au clic sur le lien FCU
<img width="377" alt="image" src="https://github.com/user-attachments/assets/1a81c346-98a2-4b51-b1ea-92a19d2abfad">

On arrive sur le site FCU avec l'adresse et le chauffage pré rempli
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/22666325-3fd9-465b-9d35-3824709343de">
