### PR TITLE
feat: add debug on title for gains energetiques

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -5,10 +5,11 @@ export type BadgeProps = {
   icon?: string;
   label: string;
   size?: "medium" | "small";
+  title?: string;
   type?: "error" | "neutral" | "success" | "warning";
 };
 
-export const Badge = ({ label, type = "neutral", icon, size = "small" }: PropsWithChildren<BadgeProps>) => {
+export const Badge = ({ label, type = "neutral", icon, size = "small", title }: PropsWithChildren<BadgeProps>) => {
   return (
     <p
       className={cx(`inline-flex items-center rounded-md px-1 py-0.5 mb-0 font-bold`, {
@@ -19,6 +20,7 @@ export const Badge = ({ label, type = "neutral", icon, size = "small" }: PropsWi
         "leading-6 text-sm": size === "medium",
         "uppercase leading-5 text-xs": size === "small",
       })}
+      title={title}
     >
       {icon && <i className={cx("fr-icon--xs mr-1", icon)} />}
       {label}

--- a/src/components/EstimationGains.tsx
+++ b/src/components/EstimationGains.tsx
@@ -55,7 +55,11 @@ export const EstimationGains = ({ solution, informationBatiment, avecMessage }: 
 
             <div></div>
             <div className="text-center">
-              <Badge label={`- ${pourcentageGain}%`} type="success" />
+              <Badge
+                label={`- ${pourcentageGain}%`}
+                type="success"
+                title={`CEP initiale: ${solution.cepAvant} | CEP future: ${solution.cepApres}`}
+              />
               <Text variant="xs" className="mb-0">
                 Gain d'énergie
               </Text>


### PR DESCRIPTION
Afin de mieux comprendre comment sont calculés les gains énergétiques sans avoir à retrouver la bonne requête SQL, j'ai ajouté au title du badge, la possibilité de mettre un texte.

Pour les gains énergétiques, on affiche le CEP initiale versus le CEP future. 

<img width="376" alt="image" src="https://github.com/user-attachments/assets/1e1c7caf-91fc-41cb-850d-0159cad910bc">
