### PR TITLE
feat: add share button for resultats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ Il faut d'abord s'authentifier.
 Créer une db, suffixée avec la date du jour au format ISO.
 
 ```shell
-turso db create pacoupa-20240913 --from-file assets/pacoupa.db
+turso db create pacoupa-20240923 --from-file assets/pacoupa.db
 ```
 
 Un token d'accès est nécessaire afin de pouvoir lire la db.
 
 Pour créer un nouveau token d'accès en lecture seule
 ```shell
-turso db tokens create pacoupa-20240913 -r 
+turso db tokens create pacoupa-20240923 -r 
 ```
 
 En développement, il faut recopier le token dans `.env` et `.env.local` (`TURSO_DATABASE_URL` et `TURSO_AUTH_TOKEN`).

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -42,9 +42,7 @@ export default function Page() {
                 }}
               />
 
-              <Button type="submit" className="btn btn-primary px-4 py-2 rounded-lg text-white">
-                Envoyer
-              </Button>
+              <Button type="submit">Envoyer</Button>
             </div>
           </form>
         </div>

--- a/src/app/simulation/resultat/Evaluation.tsx
+++ b/src/app/simulation/resultat/Evaluation.tsx
@@ -3,7 +3,7 @@
 import CloseIcon from "@mui/icons-material/Close";
 import InfoIcon from "@mui/icons-material/Info";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { Dialog, DialogContent, DialogContentText, DialogTitle, Tooltip } from "@mui/material";
+import { Dialog as MuiDialog, DialogContent, DialogContentText, DialogTitle, styled, Tooltip } from "@mui/material";
 import MuiButton from "@mui/material/Button";
 import { push } from "@socialgouv/matomo-next";
 import Image from "next/image";
@@ -84,6 +84,12 @@ const config = {
     mapper: maturiteMap,
   },
 } satisfies Record<SolutionEvaluation, { emoji?: JSX.Element; mapper: unknown; titre: string }>;
+
+const Dialog = styled(MuiDialog)(() => ({
+  "& .MuiPaper-root": {
+    borderRadius: "0.5rem",
+  },
+}));
 
 export const Evaluation = ({ categorie, solution, withDetails }: EvaluationProps) => {
   const [open, setOpen] = useState(false);

--- a/src/app/simulation/resultat/NouvelleSimulation.tsx
+++ b/src/app/simulation/resultat/NouvelleSimulation.tsx
@@ -17,7 +17,7 @@ export const NouvelleSimulation = () => {
 
   return (
     <>
-      <Button priority="tertiary no outline" iconId="ri-arrow-right-line" onClick={() => handleClick()}>
+      <Button priority="tertiary" iconId="ri-arrow-right-line" onClick={() => handleClick()}>
         Démarrer une nouvelle simulation
       </Button>
     </>

--- a/src/app/simulation/resultat/Resultat.tsx
+++ b/src/app/simulation/resultat/Resultat.tsx
@@ -157,7 +157,16 @@ export const Resultat = ({
                     <EstimationCouts solution={solution} informationBatiment={informationBatiment} />
                   </>
                 }
-                header={<Card.CardHeader image={familleImageMap[solution.familleSolution]} title={solution.nom} />}
+                header={
+                  <Card.CardHeader
+                    image={
+                      <div className="w-10 h-10 flex items-center justify-center">
+                        {familleImageMap[solution.familleSolution]}
+                      </div>
+                    }
+                    title={solution.nom}
+                  />
+                }
                 footer={
                   <Button
                     priority="primary"

--- a/src/app/simulation/resultat/Resultat.tsx
+++ b/src/app/simulation/resultat/Resultat.tsx
@@ -5,7 +5,6 @@ import { Snackbar } from "@mui/material";
 import { push } from "@socialgouv/matomo-next";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
-import { useWindowSize } from "usehooks-ts";
 
 import { Button } from "@/components/Button";
 import { Card } from "@/components/Card";
@@ -53,8 +52,6 @@ export const Resultat = ({
   const searchParams = useSearchParams();
   const router = useRouter();
   const [showToast, setShowToast] = useState(false);
-
-  const { width = 0 } = useWindowSize({ debounceDelay: 100, initializeWithValue: false });
 
   const handleClose = (event: Event | React.SyntheticEvent, reason?: string) => {
     if (reason === "clickaway") {

--- a/src/app/simulation/resultat/Resultat.tsx
+++ b/src/app/simulation/resultat/Resultat.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
+import { Snackbar } from "@mui/material";
 import { push } from "@socialgouv/matomo-next";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { useWindowSize } from "usehooks-ts";
 
 import { Button } from "@/components/Button";
 import { Card } from "@/components/Card";
@@ -49,6 +52,17 @@ export const Resultat = ({
 }: Props) => {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const [showToast, setShowToast] = useState(false);
+
+  const { width = 0 } = useWindowSize({ debounceDelay: 100, initializeWithValue: false });
+
+  const handleClose = (event: Event | React.SyntheticEvent, reason?: string) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setShowToast(false);
+  };
 
   return (
     <>
@@ -192,8 +206,32 @@ export const Resultat = ({
         </div>
       )}
 
+      <div className="flex justify-between mt-8">
+        <Button
+          priority="secondary"
+          iconId="ri-share-fill"
+          iconPosition="right"
+          onClick={() => {
+            push(["trackEvent", matomoCategory.solutionDetails, "Clic Partager", "Partager"]);
+
+            navigator.clipboard.writeText(window.location.href).catch(console.error);
+            setShowToast(true);
+          }}
+        >
+          Partager tous les résultats
+        </Button>
+
+        <Snackbar
+          anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+          open={showToast}
+          onClose={handleClose}
+          autoHideDuration={4000}
+          message="L'URL a bien été copiée 🚀."
+        ></Snackbar>
+      </div>
+
       <Grid>
-        <GridCol className="mt-12">
+        <GridCol className="mt-8">
           <NouvelleSimulation />
         </GridCol>
       </Grid>

--- a/src/app/simulation/resultat/Resultat.tsx
+++ b/src/app/simulation/resultat/Resultat.tsx
@@ -68,10 +68,9 @@ export const Resultat = ({
           Copropriété
         </H2>
         <Card
-          header={<div className="text-base font-bold">{informationBatiment.adresse}</div>}
-          headerAlign="left"
-          footer={
-            <div className="mt-4 mr-4">
+          content={
+            <div className="flex justify-between items-baseline">
+              <div className="text-base font-bold">{informationBatiment.adresse}</div>
               <Button
                 linkProps={{
                   href: "/simulation/etapes",
@@ -79,16 +78,14 @@ export const Resultat = ({
                     push(["trackEvent", matomoCategory.resultats, "Clic Modifier formulaire", "Modifier formulaire"]);
                   },
                 }}
-                priority="secondary"
+                priority="tertiary"
                 iconId="ri-pencil-line"
                 iconPosition="right"
-                className="min-h-0 w-min"
               >
                 {"Modifier"}
               </Button>
             </div>
           }
-          footerAlign="right"
         />
       </div>
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,7 +4,9 @@ import { cx } from "@codegouvfr/react-dsfr/tools/cx";
 type Props = Parameters<typeof ButtonDsfr>[0];
 
 /**
- * Custom button for Pacoupa
+ * Custom button for Pacoupa.
+ *
+ * NB: we extend from ButtonDsfr to keep the same props (linkProps/buttonProps).
  */
 export const Button = (props: Props) => {
   const { priority = "primary" } = props;
@@ -13,13 +15,18 @@ export const Button = (props: Props) => {
     <>
       <ButtonDsfr
         {...props}
-        className={cx("justify-center items-center gap-2 inline-flex text-[#304436] font-bold", props.className, {
-          "!border-solid !border !border-transparent !bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436]":
-            priority === "primary",
-          "bg-white hover:!bg-[#e7f6ec] rounded shadow border border-solid border-[#304436]": priority === "secondary",
-          "border-b-2 border-t-0 border-x-0 border-solid border-[#304436] hover:!border-[#80b990] hover:!text-[#80b990] active:!text-[#92e3a9] shadow-none px-0 bg-transparent hover:!bg-transparent active:!bg-transparent active:!border-transparent":
-            priority === "tertiary",
-        })}
+        className={cx(
+          "justify-center items-center gap-2 inline-flex text-[#304436] font-bold transition-all duration-250",
+          props.className,
+          {
+            "!border-solid !border !border-transparent !bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436]":
+              priority === "primary",
+            "bg-white hover:!bg-[#e7f6ec] rounded shadow-md border border-solid border-[#304436] active:!shadow-none active:!bg-white":
+              priority === "secondary",
+            "border-b-2 border-t-0 border-x-0 border-solid border-[#304436] hover:!border-[#80b990] hover:!text-[#80b990] active:!text-[#92e3a9] shadow-none px-0 bg-transparent hover:!bg-transparent active:!bg-transparent active:!border-transparent":
+              priority === "tertiary",
+          },
+        )}
       >
         {props.children}
       </ButtonDsfr>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,81 +1,28 @@
 import ButtonDsfr from "@codegouvfr/react-dsfr/Button";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
-import { type AnchorHTMLAttributes, type ButtonHTMLAttributes, type PropsWithChildren } from "react";
-
-import styles from "./Button.module.scss";
 
 type Props = Parameters<typeof ButtonDsfr>[0];
 
 /**
  * Custom button for Pacoupa
  */
-export const OldButton = (props: Props) => {
+export const Button = (props: Props) => {
+  const { priority = "primary" } = props;
+
   return (
     <>
       <ButtonDsfr
         {...props}
-        className={cx(
-          props.priority === "secondary"
-            ? styles.secondaryButton
-            : props.priority === "tertiary" || props.priority === "tertiary no outline"
-              ? styles.tertiaryButton
-              : styles.primaryButton,
-          props.className,
-          "w-full sm:w-auto justify-center font-bold",
-        )}
+        className={cx("justify-center items-center gap-2 inline-flex text-[#304436] font-bold", props.className, {
+          "!bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436] active:!border-solid":
+            priority === "primary",
+          "bg-white hover:!bg-[#e7f6ec] rounded shadow border border-solid border-[#304436]": priority === "secondary",
+          "border-b-2 border-t-0 border-x-0 border-solid border-[#304436] hover:!border-[#80b990] hover:!text-[#80b990] active:!text-[#92e3a9] shadow-none px-0 bg-transparent hover:!bg-transparent active:!bg-transparent active:!border-transparent":
+            priority === "tertiary",
+        })}
       >
         {props.children}
       </ButtonDsfr>
-    </>
-  );
-};
-
-type ButtonProps = {
-  priority?: "primary" | "secondary" | "tertiary";
-  size?: "medium" | "small";
-} & (
-  | {
-      buttonProps: ButtonHTMLAttributes<HTMLButtonElement>;
-      linkProps?: never;
-    }
-  | {
-      buttonProps?: never;
-      linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
-    }
-);
-
-export const Button = (props: PropsWithChildren<ButtonProps>) => {
-  const { priority = "primary", size = "medium" } = props;
-
-  const prioritySize = {
-    medium: "h-[38px] px-6 py-2",
-    small: "h-[30px] px-4 py-1",
-  };
-
-  const priorityStyle = {
-    primary:
-      "!bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436] active:!border-solid",
-    secondary: "bg-white hover:!bg-[#e7f6ec] active:!border active:!border-solid active:!border-[#304436]",
-    tertiary: "border-b-2 border-[#304436] hover:!border-[#80b990] hover:!text-[#80b990] active:!text-[#92e3a9]",
-  };
-
-  return (
-    <>
-      {props.linkProps ? (
-        <a
-          {...props.linkProps}
-          className={`justify-center items-center gap-2 inline-flex text-[#304436] font-bold ${prioritySize[size]} ${priorityStyle[priority]}`}
-        >
-          {props.children}
-        </a>
-      ) : (
-        <button
-          {...props.buttonProps}
-          className={`justify-center items-center gap-2 inline-flex text-[#304436] font-bold ${prioritySize[size]} ${priorityStyle[priority]}`}
-        >
-          {props.children}
-        </button>
-      )}
     </>
   );
 };

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,7 +14,7 @@ export const Button = (props: Props) => {
       <ButtonDsfr
         {...props}
         className={cx("justify-center items-center gap-2 inline-flex text-[#304436] font-bold", props.className, {
-          "!bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436] active:!border-solid":
+          "!border-solid !border !border-transparent !bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436]":
             priority === "primary",
           "bg-white hover:!bg-[#e7f6ec] rounded shadow border border-solid border-[#304436]": priority === "secondary",
           "border-b-2 border-t-0 border-x-0 border-solid border-[#304436] hover:!border-[#80b990] hover:!text-[#80b990] active:!text-[#92e3a9] shadow-none px-0 bg-transparent hover:!bg-transparent active:!bg-transparent active:!border-transparent":

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,6 @@
 import ButtonDsfr from "@codegouvfr/react-dsfr/Button";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
+import { type AnchorHTMLAttributes, type ButtonHTMLAttributes, type PropsWithChildren } from "react";
 
 import styles from "./Button.module.scss";
 
@@ -8,7 +9,7 @@ type Props = Parameters<typeof ButtonDsfr>[0];
 /**
  * Custom button for Pacoupa
  */
-export const Button = (props: Props) => {
+export const OldButton = (props: Props) => {
   return (
     <>
       <ButtonDsfr
@@ -25,6 +26,56 @@ export const Button = (props: Props) => {
       >
         {props.children}
       </ButtonDsfr>
+    </>
+  );
+};
+
+type ButtonProps = {
+  priority?: "primary" | "secondary" | "tertiary";
+  size?: "medium" | "small";
+} & (
+  | {
+      buttonProps: ButtonHTMLAttributes<HTMLButtonElement>;
+      linkProps?: never;
+    }
+  | {
+      buttonProps?: never;
+      linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
+    }
+);
+
+export const Button = (props: PropsWithChildren<ButtonProps>) => {
+  const { priority = "primary", size = "medium" } = props;
+
+  const prioritySize = {
+    medium: "h-[38px] px-6 py-2",
+    small: "h-[30px] px-4 py-1",
+  };
+
+  const priorityStyle = {
+    primary:
+      "!bg-[#92e3a9] hover:!bg-[#b3ebc3] rounded shadow active:!shadow-none active:!bg-[#80b990] active:!border active:!border-[#304436] active:!border-solid",
+    secondary: "bg-white hover:!bg-[#e7f6ec] active:!border active:!border-solid active:!border-[#304436]",
+    tertiary: "border-b-2 border-[#304436] hover:!border-[#80b990] hover:!text-[#80b990] active:!text-[#92e3a9]",
+  };
+
+  return (
+    <>
+      {props.linkProps ? (
+        <a
+          {...props.linkProps}
+          className={`justify-center items-center gap-2 inline-flex text-[#304436] font-bold ${prioritySize[size]} ${priorityStyle[priority]}`}
+        >
+          {props.children}
+        </a>
+      ) : (
+        <button
+          {...props.buttonProps}
+          className={`justify-center items-center gap-2 inline-flex text-[#304436] font-bold ${prioritySize[size]} ${priorityStyle[priority]}`}
+        >
+          {props.children}
+        </button>
+      )}
     </>
   );
 };

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -16,9 +16,9 @@ type CardHeaderProps = { image?: JSX.Element; title: React.ReactNode };
 
 export const CardHeader = ({ image, title }: CardHeaderProps) => {
   return (
-    <div className="flex gap-4 items-center self-start mt-2">
-      {image && <div>{image}</div>}
-      <h3 className="text-base font-bold leading-6 text-balance">{title}</h3>
+    <div className="flex gap-4 items-center mt-2">
+      {image && <>{image}</>}
+      <h3 className="text-base font-bold leading-6 text-balance mb-0">{title}</h3>
     </div>
   );
 };

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,8 +2,6 @@
 
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
 
-import { H3 } from "@/dsfr/base/typography";
-
 type Props = {
   content?: React.ReactNode;
   footer?: React.ReactNode;
@@ -18,9 +16,9 @@ type CardHeaderProps = { image?: JSX.Element; title: React.ReactNode };
 
 export const CardHeader = ({ image, title }: CardHeaderProps) => {
   return (
-    <div className="flex gap-4 items-center self-start">
+    <div className="flex gap-4 items-center self-start mt-2">
       {image && <div>{image}</div>}
-      <H3 as="h6">{title}</H3>
+      <h3 className="text-base font-bold leading-6 text-balance">{title}</h3>
     </div>
   );
 };

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -38,7 +38,7 @@ export const Card = ({
     <>
       <div
         className={cx(
-          "flex flex-col justify-start items-stretch p-4 gap-1 bg-white border-solid border-body-700 shadow rounded-lg max-w-lg h-full relative",
+          "flex flex-col justify-start items-stretch p-4 gap-1 bg-white border border-solid border-body-700 shadow rounded-lg max-w-lg h-full relative",
         )}
       >
         {/* Marker */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
   theme: {
     extend: {
       boxShadow: {
+        md: "2px 2px 0 0 var(--color-text-primary)",
         DEFAULT: "4px 4px 0 0 var(--color-green-900)",
       },
     },


### PR DESCRIPTION
- Changement taille icône + titre 
<img width="356" alt="image" src="https://github.com/user-attachments/assets/2cc45484-af9e-452a-8d69-f73464002df0">

- Refactor boutons à l'identique du design + transition
<img width="374" alt="image" src="https://github.com/user-attachments/assets/192d6ed3-2c99-4f77-95df-1264bbb04da7">

- Bouton Partager sur la liste de résultats
<img width="336" alt="image" src="https://github.com/user-attachments/assets/95eece5c-c5db-45f6-8043-f45f9e444e18">

