### PR TITLE
feat: link to FR site if no structure found via API

### DIFF
--- a/src/app/simulation/resultat/FranceRenovBlock.tsx
+++ b/src/app/simulation/resultat/FranceRenovBlock.tsx
@@ -181,112 +181,134 @@ export const FranceRenovBlock = ({ withWorkflow, showToast }: Props = {}) => {
           guider dans les premières étapes de votre projet.
         </GridCol>
 
-        <GridCol className="mt-12">
-          <Button
-            onClick={() => {
-              push([
-                "trackEvent",
-                withWorkflow ? matomoCategory.solutionDetails : matomoCategory.resultats,
-                "Clic Trouver un conseiller",
-                "Trouver un conseiller",
-              ]);
-
-              setOpen(true);
-            }}
-          >
-            Trouver un conseiller
-          </Button>
-
-          <Dialog
-            open={open}
-            onClose={() => setOpen(false)}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-            fullScreen={width > breakpoints.getPxValues().sm ? false : true}
-            fullWidth
-            maxWidth="md"
-          >
-            <DialogTitle id="alert-dialog-title" className="!mt-8 !text-[22px] !text-body-500 !pl-4">
-              Votre conseiller
-            </DialogTitle>
-
-            <MuiButton
-              variant="text"
-              endIcon={<CloseIcon />}
-              onClick={() => setOpen(false)}
-              sx={{
-                position: "absolute",
-                right: 8,
-                top: 8,
-                color: theme => theme.palette.grey[500],
+        {!franceRenovStructure && (
+          <GridCol className="mt-12">
+            <Button
+              linkProps={{
+                href: "https://france-renov.gouv.fr/preparer-projet/trouver-conseiller",
+                onClick: () => {
+                  push([
+                    "trackEvent",
+                    withWorkflow ? matomoCategory.solutionDetails : matomoCategory.resultats,
+                    "Clic Trouver un conseiller - lien générique",
+                    "Trouver un conseiller",
+                  ]);
+                },
               }}
             >
-              Fermer
-            </MuiButton>
+              Trouver un conseiller
+            </Button>
+          </GridCol>
+        )}
 
-            {/* There are warnings in the dev console on this because Mui Dialog add a p which is not convenient at all.*/}
-            {/* We don't want to add <br/> and inline-block everywhere. So the best option is to live with this React warnings.*/}
+        {franceRenovStructure && (
+          <GridCol className="mt-12">
+            <Button
+              onClick={() => {
+                push([
+                  "trackEvent",
+                  withWorkflow ? matomoCategory.solutionDetails : matomoCategory.resultats,
+                  "Clic Trouver un conseiller",
+                  "Trouver un conseiller",
+                ]);
 
-            <DialogContent>
-              <DialogContentText id="alert-dialog-description">
-                <H5>{franceRenovStructure?.Nom_Structure}</H5>
+                setOpen(true);
+              }}
+            >
+              Trouver un conseiller
+            </Button>
 
-                <Text variant="md" className="font-normal mb-0">
-                  Adresse
-                </Text>
-                <Text variant="md" className="font-medium">
-                  {franceRenovStructure?.Adresse_Structure} <br />
-                  {franceRenovStructure?.Code_Postal_Structure} {franceRenovStructure?.Commune_Structure}
-                </Text>
+            <Dialog
+              open={open}
+              onClose={() => setOpen(false)}
+              aria-labelledby="alert-dialog-title"
+              aria-describedby="alert-dialog-description"
+              fullScreen={width > breakpoints.getPxValues().sm ? false : true}
+              fullWidth
+              maxWidth="md"
+            >
+              <DialogTitle id="alert-dialog-title" className="!mt-8 !text-[22px] !text-body-500 !pl-4">
+                Votre conseiller
+              </DialogTitle>
 
-                <Text variant="md" className="font-normal mb-0">
-                  Téléphone
-                </Text>
-                <Text variant="md" className="font-medium text-primary-700">
-                  <Link href={`tel:${franceRenovStructure?.Telephone_Structure}`}>
-                    {franceRenovStructure?.Telephone_Structure}
-                  </Link>
-                </Text>
+              <MuiButton
+                variant="text"
+                endIcon={<CloseIcon />}
+                onClick={() => setOpen(false)}
+                sx={{
+                  position: "absolute",
+                  right: 8,
+                  top: 8,
+                  color: theme => theme.palette.grey[500],
+                }}
+              >
+                Fermer
+              </MuiButton>
 
-                <Text variant="md" className="font-normal mb-0">
-                  Mail
-                </Text>
-                <Text variant="md" className="font-medium text-primary-700">
-                  <Link href={`mailto:${franceRenovStructure?.Email_Structure}`}>
-                    {franceRenovStructure?.Email_Structure}
-                  </Link>
-                </Text>
+              {/* There are warnings in the dev console on this because Mui Dialog add a p which is not convenient at all.*/}
+              {/* We don't want to add <br/> and inline-block everywhere. So the best option is to live with this React warnings.*/}
 
-                <Text variant="md" className="font-normal mb-0">
-                  Site web
-                </Text>
-                {structureWebsite && (
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  <H5>{franceRenovStructure?.Nom_Structure}</H5>
+
+                  <Text variant="md" className="font-normal mb-0">
+                    Adresse
+                  </Text>
+                  <Text variant="md" className="font-medium">
+                    {franceRenovStructure?.Adresse_Structure} <br />
+                    {franceRenovStructure?.Code_Postal_Structure} {franceRenovStructure?.Commune_Structure}
+                  </Text>
+
+                  <Text variant="md" className="font-normal mb-0">
+                    Téléphone
+                  </Text>
                   <Text variant="md" className="font-medium text-primary-700">
-                    <Link
-                      href={`https://${structureWebsite}` as unknown as UrlObject}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {structureWebsite}
+                    <Link href={`tel:${franceRenovStructure?.Telephone_Structure}`}>
+                      {franceRenovStructure?.Telephone_Structure}
                     </Link>
                   </Text>
-                )}
 
-                {structureHoraires && (
-                  <div className="mt-8 border-solid border-l-4 border-y-0 border-r-0 border-primary-700 pl-4">
-                    {structureHoraires.map(ligne => (
-                      <div key={ligne}>
-                        <Text variant="md" className="font-normal mb-0">
-                          {ligne}
-                        </Text>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </DialogContentText>
-            </DialogContent>
-          </Dialog>
-        </GridCol>
+                  <Text variant="md" className="font-normal mb-0">
+                    Mail
+                  </Text>
+                  <Text variant="md" className="font-medium text-primary-700">
+                    <Link href={`mailto:${franceRenovStructure?.Email_Structure}`}>
+                      {franceRenovStructure?.Email_Structure}
+                    </Link>
+                  </Text>
+
+                  <Text variant="md" className="font-normal mb-0">
+                    Site web
+                  </Text>
+                  {structureWebsite && (
+                    <Text variant="md" className="font-medium text-primary-700">
+                      <Link
+                        href={`https://${structureWebsite}` as unknown as UrlObject}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {structureWebsite}
+                      </Link>
+                    </Text>
+                  )}
+
+                  {structureHoraires && (
+                    <div className="mt-8 border-solid border-l-4 border-y-0 border-r-0 border-primary-700 pl-4">
+                      {structureHoraires.map(ligne => (
+                        <div key={ligne}>
+                          <Text variant="md" className="font-normal mb-0">
+                            {ligne}
+                          </Text>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </DialogContentText>
+              </DialogContent>
+            </Dialog>
+          </GridCol>
+        )}
       </Grid>
     </>
   );


### PR DESCRIPTION
Si l'API donnant les structures France Renov ne nous rend aucun résultat (ex: 10 Avenue Maréchal Foch 06000 Nice), le bouton Trouver un conseiller devient un lien vers la page externe du site officiel France Renov. 

<img width="823" alt="image" src="https://github.com/user-attachments/assets/8d982970-5fc8-40d9-8c64-21cbd01bb44a">

Clic sur bouton
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/2c68c17b-4b7f-471c-ab87-434a0133bb37">


Sinon, le bouton Trouver un conseiller appelle une boîte de dialogue montrant les informations de la structure FR liée à l'adresse de l'utilisateur.

<img width="876" alt="image" src="https://github.com/user-attachments/assets/7f80e33a-a440-405e-b42a-b1088a442b4b">

<img width="918" alt="image" src="https://github.com/user-attachments/assets/2dc41b33-52fc-4043-86ac-985d9313f497">

