### PR TITLE
feat: tasks for Mon Service Sécurisé

### DIFF
--- a/src/app/(default)/politique-de-confidentialite/page.tsx
+++ b/src/app/(default)/politique-de-confidentialite/page.tsx
@@ -44,8 +44,15 @@ export default function PolitiqueConfidentialite() {
             name: "Vercel",
             country: "États-Unis",
             hostingCountry: "France (AWS cdg1)",
-            serviceType: "Hébergement",
+            serviceType: "Hébergement du site web",
             policyUrl: "https://vercel.com/legal/privacy-policy",
+          },
+          {
+            name: "Turso",
+            country: "États-Unis",
+            hostingCountry: "France, Paris",
+            serviceType: "Hébergement des données",
+            policyUrl: "https://turso.tech/privacy-policy",
           },
           // {
           //   name: "<Renseigner le nom du service>",

--- a/src/app/(default)/politique-de-confidentialite/page.tsx
+++ b/src/app/(default)/politique-de-confidentialite/page.tsx
@@ -38,6 +38,14 @@ export default function PolitiqueConfidentialite() {
             editor: "Matomo & ADEME",
             destination: "France",
           },
+          {
+            category: "Hébergement de formulaires",
+            name: "Tally",
+            expiration: "7 jours",
+            finalities: "Mesure d’audience",
+            editor: "Tally",
+            destination: "France",
+          },
         ]}
         thirdParties={[
           {
@@ -54,14 +62,27 @@ export default function PolitiqueConfidentialite() {
             serviceType: "Hébergement des données",
             policyUrl: "https://turso.tech/privacy-policy",
           },
-          // {
-          //   name: "<Renseigner le nom du service>",
-          //   country: "<Pays d’origine du service>",
-          //   hostingCountry:
-          //     "<Si le service permet de changer la localisation du stockage ou du transit des données, le préciser>",
-          //   serviceType: "<Renseigner le type service (Hébergement, bdd, etc.)>",
-          //   policyUrl: "<Ajouter le lien de la politique de confidentialité du service>",
-          // },
+          {
+            name: "Matomo",
+            country: "États-Unis",
+            hostingCountry: "Europe",
+            serviceType: "Mesure d’audience anonymisée",
+            policyUrl: "https://fr.matomo.org/privacy-policy/",
+          },
+          {
+            name: "Sentry",
+            country: "États-Unis",
+            hostingCountry: "Europe",
+            serviceType: "Surveillance des erreurs",
+            policyUrl: "https://sentry.io/privacy/",
+          },
+          {
+            name: "Tally",
+            country: "Belgique",
+            hostingCountry: "Europe",
+            serviceType: "Hébergement de formulaires",
+            policyUrl: "https://tally.so/help/terms-and-privacy",
+          },
         ]}
       />
     </div>

--- a/src/app/contact/DetailContact.tsx
+++ b/src/app/contact/DetailContact.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { config } from "@/config";
+import { useConsent } from "@/consentManagement";
+import { useScrollTop } from "@/lib/client/useScrollTop";
+
+export const DetailContact = () => {
+  useScrollTop();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const { finalityConsent } = useConsent();
+
+  useEffect(() => {
+    if (finalityConsent?.tally) {
+      if (iframeRef.current) {
+        iframeRef.current.src = `https://tally.so/embed/${config.tally.contact.id}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1`;
+      }
+    }
+  }, [finalityConsent?.tally]);
+
+  return (
+    <>
+      {finalityConsent?.tally ? (
+        <div className="border border-solid border-body-700 shadow rounded-lg px-16 pb-8">
+          <iframe ref={iframeRef} loading="eager" width="100%" height="100%" title="Page de contact" allowFullScreen />
+        </div>
+      ) : (
+        <div>
+          <a href="mailto:pacoupa@beta.gouv.fr">Écrire à l'équipe Pacoupa</a>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,26 +1,12 @@
-"use client";
-
 import Link from "next/link";
-import { useEffect, useRef } from "react";
 
+import { ClientOnly } from "@/components/ClientOnly";
 import { config } from "@/config";
 import { H1 } from "@/dsfr/base/typography";
-import { useScrollTop } from "@/lib/client/useScrollTop";
 
-/**
- * This page needs to be a client component because it uses the `useScrollTop` hook and the `iframe` element.
- * The iframe must be fetched client side in order to work in client navigation.
- */
+import { DetailContact } from "./DetailContact";
+
 const ContactPage = () => {
-  useScrollTop();
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-
-  useEffect(() => {
-    if (iframeRef.current) {
-      iframeRef.current.src = `https://tally.so/embed/${config.tally.contact.id}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1`;
-    }
-  }, []);
-
   return (
     <div className="col-start-2 mt-10 md:mt-20 relative ">
       <H1 className="relative md:before:content-[''] before:block before:absolute before:top-[-35px] before:left-[-55px] before:w-full before:h-[91px] before:max-w-[650px] before:bg-[url('/img/dot.png')] before:bg-no-repeat">
@@ -34,9 +20,9 @@ const ContactPage = () => {
         question.
       </p>
 
-      <div className="border border-solid border-body-700 shadow rounded-lg px-16 pb-8">
-        <iframe ref={iframeRef} loading="eager" width="100%" height="100%" title="Page de contact" allowFullScreen />
-      </div>
+      <ClientOnly>
+        <DetailContact />
+      </ClientOnly>
     </div>
   );
 };

--- a/src/components/PacoupaFooter.tsx
+++ b/src/components/PacoupaFooter.tsx
@@ -2,7 +2,7 @@ import { Footer } from "@codegouvfr/react-dsfr/Footer";
 import { type HeaderProps } from "@codegouvfr/react-dsfr/Header";
 
 import { config } from "@/config";
-import { FooterPersonalDataPolicyItem } from "@/consentManagement";
+import { FooterConsentManagementItem, FooterPersonalDataPolicyItem } from "@/consentManagement";
 
 import styles from "./PacoupaFooter.module.scss";
 
@@ -34,11 +34,7 @@ export const PacoupaFooter = () => {
             text: "Politique des cookies",
             linkProps: { href: "/politique-des-cookies" },
           },
-          // {
-          //   ...headerFooterDisplayItem,
-          //   iconId: "fr-icon-theme-fill",
-          // },
-          // <FooterConsentManagementItem key="FooterConsentManagementItem" />,
+          <FooterConsentManagementItem key="FooterConsentManagementItem" />,
           {
             text: <>▲&nbsp;Propulsé par Vercel</>,
             linkProps: {

--- a/src/consentManagement.tsx
+++ b/src/consentManagement.tsx
@@ -13,6 +13,10 @@ export const {
       title: "Matomo",
       description: "Outil d’analyse comportementale des utilisateurs.",
     },
+    tally: {
+      title: "Tally",
+      description: "Hébergement de formulaires.",
+    },
   },
   personalDataPolicyLinkProps: {
     href: "/politique-de-confidentialite#cookies",


### PR DESCRIPTION
Ajout du cookie Tally dans la bannière de consentement. 
<img width="978" alt="image" src="https://github.com/user-attachments/assets/461698e5-8f7e-4ffe-9871-2fb2a6eab105">


Si le cookie Tally est accepté, on affiche comme avant l'iframe pour la page contact et la popup sur la page de résultat. 

S'il n'est pas accepté, on affiche un lien mailto sur la page contact et on n'affiche pas la popup sur la page de résultat. 

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/fbb51478-38cd-4499-9330-b95989b0c35d">

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/6f8f2251-59b7-4203-95b2-e9db0bc3d768">

Ajout d'un bouton Gestion de cookies pour pouvoir afficher la popup de consentement quand l'utilisateur le souhaite. 

![gestion cookies lien](https://github.com/user-attachments/assets/67887032-42a3-4da7-b0e2-b5ac52745301)


Également, mise en conformité des pages Politique de confidentialité et Politique de cookies, pour afficher tous les services tierces. 

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/6d88f40a-c60a-4344-bddf-045bc2dd8355">

